### PR TITLE
fix: 翻译提示框，顶部高度不够时样式显示有误

### DIFF
--- a/content_scripts/tip.jsx
+++ b/content_scripts/tip.jsx
@@ -115,7 +115,7 @@ function makeTipEl(root, options, isBottom) {
           style="position: absolute;
         left: 50%;
         transform: translateX(-50%);
-        bottom: 0px;
+        bottom: ${isBottom ? '0' : 'initial'};
         width: 36px;
         height: 24px;
         line-height: 24px;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3961388/102970920-5c5a4300-4533-11eb-85b3-cbafd7410319.png)


感谢作者做了个这么实用的扩展，非常好用 😀

另外很好奇是怎么做到不需要预编译就能运行 `jsx` 文件的？ 看到有 `standalone.module.mini.js` 和 `webcomponents-sd-ce.js` 但不是很明白，可以简单说一下吗？