### PR TITLE
feat：显示单词的考纲要求(exam_type)

### DIFF
--- a/content_scripts/tip.jsx
+++ b/content_scripts/tip.jsx
@@ -217,6 +217,7 @@ function makeTipEl(root, options, isBottom) {
                   fill="#666"
                 ></path>
               </svg>
+              <span style="margin-left: 8px;color: #2796f8;">${tfData.basic&&tfData.basic['exam_type'] ? '[' + tfData.basic['exam_type'][0] + ']' : ''}</span>
             </div>`
           : ''}
 

--- a/popup/common.js
+++ b/popup/common.js
@@ -41,6 +41,7 @@ const TfCard = ({ tfData }) => {
             fill="#666"
           ></path>
         </svg>
+        <span style="margin-left: 8px;color: #2796f8;">${tfData.basic&&tfData.basic['exam_type'] ? '[' + tfData.basic['exam_type'][0] + ']' : ''}</span>
       </div>
 
       <div class="flex: 1">

--- a/popup/page-material.js
+++ b/popup/page-material.js
@@ -40,6 +40,7 @@ const SuperCard = ({ material, needLearn }) => {
             >
               ${material.text}
             </div>
+            <span style="color: #2796f8;">${material.youdao.basic&&material.youdao.basic['exam_type'] ? '[' + material.youdao.basic['exam_type'][0] + ']' : ''}</span>
             ${needLearn
               ? ''
               : html`<div


### PR DESCRIPTION
### 效果

![显示单词考纲](https://user-images.githubusercontent.com/44538971/123589282-988c9a00-d81b-11eb-9c54-4036ab902e91.png)


### 详细描述

在不影响现有布局和样式的情况下，在单词附近显示最低的`考纲要求`

`最低的考纲要求`：例：transaction 的全部`考纲要求`为

```json
["CET4", "CET6", "考研", "IELTS", "TOEFL", "GRE", "GMAT", "商务英语"]
```

则只需显示最低的`考纲要求`：CET4

### 作用区域

在以下面板显示单词的`考纲要求`：

1. 划词翻译面板
2. 单词卡片面板
3. 单词卡片翻转面板

### 申请pr的想法

显示单词的`考纲要求`后，可以对单词有有更全面的认识，由此用户可以根据自己的需要选择收藏或记忆特定的`考纲词汇`。

可以重点选择记忆`考纲词汇`，而较少关注`超纲词汇`或`生僻词汇`

这样可以更有针对性地学习单词

![显示单词考纲_单词卡片面板](https://user-images.githubusercontent.com/44538971/123589332-a5a98900-d81b-11eb-82c1-42ff8845279f.png)




![显示单词考纲_单词卡片翻转面板](https://user-images.githubusercontent.com/44538971/123589364-ae01c400-d81b-11eb-96bf-c7c1c71f4e07.png)


